### PR TITLE
Add SpotifyTrack type and improve adaptTracks typing

### DIFF
--- a/src/types/ITrack.d.ts
+++ b/src/types/ITrack.d.ts
@@ -1,5 +1,5 @@
 export interface ITrack {
-  id: number;
+  id: string;
   name: string;
   artist: string;
   albumImage: string;

--- a/src/types/SpotifyTrack.d.ts
+++ b/src/types/SpotifyTrack.d.ts
@@ -1,0 +1,6 @@
+export interface SpotifyTrack {
+  id: string;
+  name: string;
+  artists: { name: string }[];
+  album: { images: { url: string }[] };
+}

--- a/src/utils/adaptTracks.ts
+++ b/src/utils/adaptTracks.ts
@@ -1,5 +1,8 @@
-export const adaptTracks = (tracks: object[]) => {
-  return tracks.map((track: any) => ({
+import { SpotifyTrack } from "../types/SpotifyTrack";
+import type { ITrack } from "../types/ITrack";
+
+export const adaptTracks = (tracks: SpotifyTrack[]): ITrack[] => {
+  return tracks.map((track) => ({
     id: track.id,
     name: track.name,
     artist: track.artists[0].name,


### PR DESCRIPTION
## Summary
- type `id` as `string` in `ITrack`
- define new `SpotifyTrack` interface
- update `adaptTracks` to use typed input and output

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a0b2bfb74832bad87febd4afc1b00